### PR TITLE
fix: provider version syntax

### DIFF
--- a/examples/coffee/main.tf
+++ b/examples/coffee/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     hashicups = {
-      versions = ["0.2"]
-      source = "hashicorp.com/edu/hashicups"
+      version = "0.2"
+      source  = "hashicorp.com/edu/hashicups"
     }
   }
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     hashicups = {
-      versions = ["0.2"]
-      source = "hashicorp.com/edu/hashicups"
+      version = "0.2"
+      source  = "hashicorp.com/edu/hashicups"
     }
   }
 }


### PR DESCRIPTION
This change will mitigate "Error: Invalid required_providers object" messages while following the provider tutorial at https://learn.hashicorp.com/tutorials/terraform/provider-setup.