### PR TITLE
Adjusts the terraform required_providers blocks under examples

### DIFF
--- a/examples/coffee/main.tf
+++ b/examples/coffee/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     hashicups = {
-      versions = ["0.2"]
+      version = "0.3"
       source = "hashicorp.com/edu/hashicups"
     }
   }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     hashicups = {
-      versions = ["0.3"]
+      version = "0.3"
       source = "hashicorp.com/edu/hashicups"
     }
   }


### PR DESCRIPTION
This PR adjusts the terraform required_providers blocks under the examples directory to work with `terraform init`.  

They are correct in the learning branches and so thought a checkout of the primary branch would need them.  Checked them with terraform 0.14 and 0.15.

Not sure if the primary branch is focusing on a future HCL structure, but thought to raise anyway :)
