### PR TITLE
podman alternative for docker-compose

### DIFF
--- a/docker_compose/podman-play-kube.yaml
+++ b/docker_compose/podman-play-kube.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hashicups
+spec:
+  containers:
+  - name: api
+    image: hashicorpdemoapp/product-api:v4280cf7
+    ports:
+    - { hostPort: 19090, containerPort: 9090, protocol: TCP }
+    volumeMounts:
+    - { name: conf_json, mountPath: /config/config.json }
+    env:
+    - { name: CONFIG_FILE, value: /config/config.json }
+  - name: db
+    image: hashicorpdemoapp/product-api-db:v4280cf7
+    ports:
+    - { hostPort: 15432, containerPort: 5432, protocol: TCP }
+    env:
+    - { name: POSTGRES_DB, value: products }
+    - { name: POSTGRES_USER, value: postgres }
+    - { name: POSTGRES_PASSWORD, value: password }
+  hostAliases:
+  - ip: 127.0.0.1
+    hostnames:
+    - db
+  volumes:
+  - name: conf_json
+    hostPath:
+      type: File
+      path: ./conf.json


### PR DESCRIPTION
This file was created following this guide;
https://www.redhat.com/sysadmin/compose-kubernetes-podman

In short; setting up podman.socket, running docker-compose,
generating the kubernetes yaml, stripping down the superfluous
keys/options/whatnot, then restructuring the yaml to look as close
to the original docker-compose.yml

Since both containers are running in the same pod, they share the
same networkstack, so one quirk is the addition of hostAliases to
get around the dns-lookup of 'db' from the api container.