### PR TITLE
Adding hashicups_ingredients to Provider DataSourcesMap

### DIFF
--- a/hashicups/provider.go
+++ b/hashicups/provider.go
@@ -33,8 +33,9 @@ func Provider() *schema.Provider {
 			"hashicups_order": resourceOrder(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"hashicups_coffees": dataSourceCoffees(),
-			"hashicups_order":   dataSourceOrder(),
+			"hashicups_coffees":     dataSourceCoffees(),
+			"hashicups_order":       dataSourceOrder(),
+			"hashicups_ingredients": dataSourceIngredients(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}


### PR DESCRIPTION
The [Read coffee ingredients](https://learn.hashicorp.com/tutorials/terraform/provider-use?in=terraform/providers#read-coffee-ingredients) part of the [Perform CRUD Operations with Providers](https://learn.hashicorp.com/tutorials/terraform/provider-use?in=terraform/providers) tutorial generates the following error when using the [binary built from source](https://learn.hashicorp.com/tutorials/terraform/provider-use?in=terraform/providers#install-hashicups-provider).

> │ Error: Invalid data source
│ 
│   on main.tf line 34, in data "hashicups_ingredients" "first_coffee":
│   34: data "hashicups_ingredients" "first_coffee" {
│ 
│ The provider hashicorp.com/edu/hashicups does not support data source "hashicups_ingredients".

This PR just adds `hashicups_ingredients` into the DataSourcesMap in order to address this issue.