### PR TITLE
Versions should match what's expected

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     hashicups = {
-      versions = ["0.3.0"]
+      version = "0.3.1"
       source = "hashicorp.com/edu/hashicups"
     }
   }


### PR DESCRIPTION
0.3.1 is the expected version, 0.3.0 causes errors. Having versions as a list and instead of "version" causes errors as well.