### PR TITLE
Remove deprecated `-i` flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install: build
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
 test: 
-	go test -i $(TEST) || exit 1                                                   
+	go test $(TEST) || exit 1
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
 testacc: 


### PR DESCRIPTION
Running `make test` raises a deprecation warning:

```
$ make test
go test -i $(go list ./... | grep -v 'vendor') || exit 1                                                   
go: -i flag is deprecated
```

This PR removes the `-i` flag in order to avoid this.