### PR TITLE
Upgrade docker versions to support M1 Macs

### DIFF
--- a/docker_compose/docker-compose.yml
+++ b/docker_compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   api:
-    image: "hashicorpdemoapp/product-api:v4280cf7"
+    image: "hashicorpdemoapp/product-api:v0.0.22"
     ports:
       - "19090:9090"
     volumes:
@@ -11,7 +11,7 @@ services:
     depends_on:
       - db
   db:
-    image: "hashicorpdemoapp/product-api-db:v4280cf7"
+    image: "hashicorpdemoapp/product-api-db:v0.0.22"
     ports:
       - "15432:5432"
     environment:


### PR DESCRIPTION
Current example doesn't work on apple M1 macs. 

```
docker compose up
[+] Running 2/0
 ⠿ Container docker_compose-db-1   Created                                                                                                                                                                                                                      0.0s
 ⠿ Container docker_compose-api-1  Recreated                                                                                                                                                                                                                    0.0s
Attaching to docker_compose-api-1, docker_compose-db-1
docker_compose-db-1   | standard_init_linux.go:228: exec user process caused: exec format error
docker_compose-db-1 exited with code 1
docker_compose-api-1  | standard_init_linux.go:228: exec user process caused: exec format error
```

```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

Implements this change https://github.com/hashicorp-demoapp/product-api-go/pull/19/files