### PR TITLE
Update provider index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,4 +34,4 @@ provider "hashicups" {
 
 - **username** (String, Optional) Username to authenticate to HashiCups API
 - **password** (String, Optional) Password to authenticate to HashiCups API
-- **host** (String, Optional) HashiCups API address (defaults to `localhost:19090`)
+- **host** (String, Optional) HashiCups API address (defaults to `http://localhost:19090`)


### PR DESCRIPTION
Add missing schema "http://" in the default example of "host".

According to the example of `localhost:19090`, I use a different host than `localhost`, I put in `host.docker.internal:19090`, and got `Unable to authenticate user for authenticated HashiCups client`.

Then I change to `http://host.docker.internal:19090`, and it works.
