### PR TITLE
fix Incompatible provider version error, solve support darwin_amd64 only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ NAMESPACE=edu
 NAME=hashicups
 BINARY=terraform-provider-${NAME}
 VERSION=0.3.1
-OS_ARCH=darwin_amd64
+GOHOSTOS=$(shell go env GOHOSTOS)
+GOARCH=$(shell go env GOARCH)
+OS_ARCH=${GOHOSTOS}_${GOARCH}
 
 default: install
 


### PR DESCRIPTION
solve the error below:


│ Error: Incompatible provider version
│
│ Provider hashicorp.com/edu/hashicups v0.3.1 does not have a package available for your current platform, darwin_arm64.
│

This is because the value of OS_ARCH is hard-coded，which is wrong for Apple M1/M2 macbook