### PR TITLE
Remove dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,10 +2,6 @@
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependency updates are being handled by TSCCR and can conflict with those generated by dependabot, for example - https://github.com/hashicorp/terraform-provider-hashicups/pull/106

This PR removes handling of dependencies by dependabot so that all dependency updates are handled solely by TSCCR.